### PR TITLE
Add test oct

### DIFF
--- a/src/oct.c
+++ b/src/oct.c
@@ -397,28 +397,3 @@ void OCT_toStr(octet *src,char *dst)
         sprintf(&dst[i],"%c", ch);
     }
 }
-
-/* Test program
-#include <stdio.h>
-#include "amcl.h"
-
-char test[]="abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
-
-int main()
-{
-	char gm[100],gn[100],t[100];
-    octet m={0,sizeof(gm),gm};
-    octet n={0,sizeof(gn),gn};
-
-	OCT_jbytes(&m,test,strlen(test));
-	OCT_output(&m);
-
-	OCT_tobase64(t,&m);
-	printf(t); printf("\n");
-
-	OCT_frombase64(&n,t);
-	OCT_output(&n);
-
-    return 0;
-}
-*/

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,17 +16,20 @@ endmacro ()
 add_executable (test_rsa test_rsa.c)
 add_executable (test_ecc test_ecc.c)
 add_executable (test_version test_version.c)
-add_executable (test_octet test_octet.c)
+add_executable (test_BIG_consistency test_big_consistency.c)
+add_executable (test_octet_consistency test_octet_consistency.c)
 # Link the executable to the libraries
 target_link_libraries (test_rsa rsa) 
 target_link_libraries (test_ecc ecdh) 
 target_link_libraries (test_version amcl) 
-target_link_libraries (test_octet amcl)
+target_link_libraries (test_octet_consistency amcl)
+target_link_libraries (test_BIG_consistency amcl )
 # run tests
 do_test (test_rsa "SUCCESS")
 do_test (test_ecc "SUCCESS")
 do_test (test_version "Version: ${AMCL_VERSION_MAJOR}.${AMCL_VERSION_MINOR}.${AMCL_VERSION_PATCH}")
-do_test (test_octet "SUCCESS")
+do_test (test_octet_consistency "SUCCESS")
+do_test (test_BIG_consistency "SUCCESS")
 
 # curve independent tests
 add_executable (test_hash test_hash.c)
@@ -84,14 +87,6 @@ add_test(NAME test_aes_decrypt_CTR_128 COMMAND ${TARGET_SYSTEM_EMULATOR} test_ae
 set_tests_properties (test_aes_decrypt_CTR_128 PROPERTIES PASS_REGULAR_EXPRESSION SUCCESS)
 add_test(NAME test_aes_decrypt_CTR_256 COMMAND ${TARGET_SYSTEM_EMULATOR} test_aes_decrypt ${PROJECT_SOURCE_DIR}/testVectors/aes/amcl_CTRMCL256.rsp  CTR)
 set_tests_properties (test_aes_decrypt_CTR_256 PROPERTIES PASS_REGULAR_EXPRESSION SUCCESS)
-
-# Test on Arithmetic
-# smoke tests  
-add_executable (test_BIG_arithmetic test_big_arithmetic.c)
-# Link the executable to the libraries
-target_link_libraries (test_BIG_arithmetic amcl )
-# tests  
-do_test (test_BIG_arithmetic "SUCCESS")
 
 if(BUILD_MPIN)
   add_executable (test_mpin test_mpin.c)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,14 +16,17 @@ endmacro ()
 add_executable (test_rsa test_rsa.c)
 add_executable (test_ecc test_ecc.c)
 add_executable (test_version test_version.c)
+add_executable (test_octet test_octet.c)
 # Link the executable to the libraries
 target_link_libraries (test_rsa rsa) 
 target_link_libraries (test_ecc ecdh) 
 target_link_libraries (test_version amcl) 
+target_link_libraries (test_octet amcl)
 # run tests
 do_test (test_rsa "SUCCESS")
 do_test (test_ecc "SUCCESS")
 do_test (test_version "Version: ${AMCL_VERSION_MAJOR}.${AMCL_VERSION_MINOR}.${AMCL_VERSION_PATCH}")
+do_test (test_octet "SUCCESS")
 
 # curve independent tests
 add_executable (test_hash test_hash.c)
@@ -36,7 +39,8 @@ target_link_libraries (test_hash amcl)
 target_link_libraries (test_gcm_encrypt amcl) 
 target_link_libraries (test_gcm_decrypt amcl) 
 target_link_libraries (test_aes_encrypt amcl) 
-target_link_libraries (test_aes_decrypt amcl) 
+target_link_libraries (test_aes_decrypt amcl)
+ 
 
 # hash tests
 add_test(NAME test_hash_256 COMMAND ${TARGET_SYSTEM_EMULATOR} test_hash ${PROJECT_SOURCE_DIR}/testVectors/sha/256/SHA256ShortMsg.rsp sha256)

--- a/test/test_big_consistency.c
+++ b/test/test_big_consistency.c
@@ -1,7 +1,7 @@
 /**
  * @file test_BIG_arithmetic.c
  * @author Alessandro Budroni
- * @brief Test for aritmetics with BIG
+ * @brief Test for consistency with BIG
  *
  * LICENSE
  *

--- a/test/test_octet.c
+++ b/test/test_octet.c
@@ -45,6 +45,37 @@ int main()
     for (i=0; i<256; i++) raw[i]=(char)i;
     RAND_seed(&rng,256,raw);
 
+    /* test comparison */
+    for (len = 1; len <= 101; len=len+10)
+    {
+        OCT_rand(&W,&rng,len);
+        OCT_copy(&V,&W);
+        if(!OCT_comp(&V,&W))
+        {
+            printf("ERROR comparing two equal octet, OCTET\n");
+            exit(EXIT_FAILURE);
+        }
+        for (i = 0; i < len; ++i) {
+            if(!OCT_ncomp(&V,&W,i))
+            {
+                printf("ERROR comparing two equal octet, OCTET\n");
+                exit(EXIT_FAILURE);
+            }
+        }
+        OCT_rand(&V,&rng,len);
+        if(OCT_comp(&V,&W))
+        {
+            printf("ERROR comparing two different octet, OCTET\n");
+            exit(EXIT_FAILURE);
+        }
+    }
+    OCT_rand(&W,&rng,0);
+    OCT_copy(&V,&W);
+    if(!OCT_comp(&V,&W))
+    {
+        printf("ERROR comparing two equal octet, OCTET\n");
+        exit(EXIT_FAILURE);
+    }
 
     for (len = 100; len > 0; len=len-10)
     {
@@ -93,6 +124,8 @@ int main()
             }
         }
     }
+
+
 
     printf("SUCCESS\n");
     return 0;

--- a/test/test_octet.c
+++ b/test/test_octet.c
@@ -1,0 +1,100 @@
+/**
+ * @file test_octet.c
+ * @author Alessandro Budroni
+ * @brief Test function for ECC
+ *
+ * LICENSE
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* test driver and function exerciser for ECDH/ECIES/ECDSA API Functions */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+#include "amcl.h"
+
+int main()
+{
+    int i,j,len=100;
+    int len64 = ((len/3) + 2)*4+1, lenHex = 28*len;
+    char raw[256], bytes[len], bytes64[len64], bytesHex[lenHex], v[len], w[len];
+    octet V={0,sizeof(v),v}, W={0,sizeof(w),w};
+    csprng rng;
+
+    /* Fake random source */
+    RAND_clean(&rng);
+    for (i=0;i<256;i++) raw[i]=(char)i;
+    RAND_seed(&rng,256,raw);
+
+
+    for (len = 100; len > 0; len=len-10) {
+
+    	W.max = len; V.max = len;
+		/* test conversion to and from base64 */
+		for (j = 0; j < 10; ++j)
+		{
+			OCT_rand(&W,&rng,len);
+			OCT_copy(&V,&W);
+			OCT_tobase64(bytes64,&W);
+			OCT_frombase64(&W,bytes64);
+			if(!OCT_comp(&V,&W))
+			{
+				printf("ERROR converting to and from base64 OCTET\n");
+				exit(EXIT_FAILURE);
+			}
+		}
+
+		/* test conversion to and from hex */
+		for (i = 0; i < 10; ++i)
+		{
+			OCT_rand(&W,&rng,len);
+			OCT_copy(&V,&W);
+			OCT_toHex(&W,bytesHex);
+			OCT_fromHex(&W,bytesHex);
+			if(!OCT_comp(&V,&W))
+			{
+				printf("ERROR converting to and from Hex OCTET\n");
+				exit(EXIT_FAILURE);
+			}
+		}
+
+		/* test conversion to and from string */
+		for (i = 0; i < 10; ++i)
+		{
+			OCT_rand(&W,&rng,len);
+			OCT_copy(&V,&W);
+			OCT_toStr(&W,bytes);
+			OCT_jstring(&W,bytes);
+			if(!OCT_comp(&V,&W))
+			{
+				printf("ERROR converting to and from string OCTET\n");
+				exit(EXIT_FAILURE);
+			}
+		}
+
+    }
+
+
+    printf("SUCCESS\n");
+    return 0;
+}
+

--- a/test/test_octet.c
+++ b/test/test_octet.c
@@ -36,63 +36,63 @@ int main()
 {
     int i,j,len=100;
     int len64 = ((len/3) + 2)*4+1, lenHex = 28*len;
-    char raw[256], bytes[len], bytes64[len64], bytesHex[lenHex], v[len], w[len];
-    octet V={0,sizeof(v),v}, W={0,sizeof(w),w};
+    char raw[256], bytes[len+1], bytes64[len64+1], bytesHex[lenHex+1], v[len], w[len];
+    octet V= {0,sizeof(v),v}, W= {0,sizeof(w),w};
     csprng rng;
 
     /* Fake random source */
     RAND_clean(&rng);
-    for (i=0;i<256;i++) raw[i]=(char)i;
+    for (i=0; i<256; i++) raw[i]=(char)i;
     RAND_seed(&rng,256,raw);
 
 
-    for (len = 100; len > 0; len=len-10) {
+    for (len = 100; len > 0; len=len-10)
+    {
 
-    	W.max = len; V.max = len;
-		/* test conversion to and from base64 */
-		for (j = 0; j < 10; ++j)
-		{
-			OCT_rand(&W,&rng,len);
-			OCT_copy(&V,&W);
-			OCT_tobase64(bytes64,&W);
-			OCT_frombase64(&W,bytes64);
-			if(!OCT_comp(&V,&W))
-			{
-				printf("ERROR converting to and from base64 OCTET\n");
-				exit(EXIT_FAILURE);
-			}
-		}
+        W.max = len;
+        V.max = len;
+        /* test conversion to and from base64 */
+        for (j = 0; j < 10; ++j)
+        {
+            OCT_rand(&W,&rng,len);
+            OCT_copy(&V,&W);
+            OCT_tobase64(bytes64,&W);
+            OCT_frombase64(&W,bytes64);
+            if(!OCT_comp(&V,&W))
+            {
+                printf("ERROR converting to and from base64 OCTET\n");
+                exit(EXIT_FAILURE);
+            }
+        }
 
-		/* test conversion to and from hex */
-		for (i = 0; i < 10; ++i)
-		{
-			OCT_rand(&W,&rng,len);
-			OCT_copy(&V,&W);
-			OCT_toHex(&W,bytesHex);
-			OCT_fromHex(&W,bytesHex);
-			if(!OCT_comp(&V,&W))
-			{
-				printf("ERROR converting to and from Hex OCTET\n");
-				exit(EXIT_FAILURE);
-			}
-		}
+        /* test conversion to and from hex */
+        for (i = 0; i < 10; ++i)
+        {
+            OCT_rand(&W,&rng,len);
+            OCT_copy(&V,&W);
+            OCT_toHex(&W,bytesHex);
+            OCT_fromHex(&W,bytesHex);
+            if(!OCT_comp(&V,&W))
+            {
+                printf("ERROR converting to and from Hex OCTET\n");
+                exit(EXIT_FAILURE);
+            }
+        }
 
-		/* test conversion to and from string */
-		for (i = 0; i < 10; ++i)
-		{
-			OCT_rand(&W,&rng,len);
-			OCT_copy(&V,&W);
-			OCT_toStr(&W,bytes);
-			OCT_jstring(&W,bytes);
-			if(!OCT_comp(&V,&W))
-			{
-				printf("ERROR converting to and from string OCTET\n");
-				exit(EXIT_FAILURE);
-			}
-		}
-
+        /* test conversion to and from string */
+        for (i = 0; i < 10; ++i)
+        {
+            OCT_rand(&W,&rng,len);
+            OCT_copy(&V,&W);
+            OCT_toStr(&W,bytes);
+            OCT_jstring(&W,bytes);
+            if(!OCT_comp(&V,&W))
+            {
+                printf("ERROR converting to and from string, OCTET\n");
+                exit(EXIT_FAILURE);
+            }
+        }
     }
-
 
     printf("SUCCESS\n");
     return 0;

--- a/test/test_octet_consistency.c
+++ b/test/test_octet_consistency.c
@@ -1,7 +1,7 @@
 /**
- * @file test_octet.c
+ * @file test_octet_consistency.c
  * @author Alessandro Budroni
- * @brief Test function for ECC
+ * @brief Test function for octect consistency
  *
  * LICENSE
  *


### PR DESCRIPTION
- Add consistency test for transformation of OCT to/from char, hex, base64
- Change name of test_BIG_arithmetics to test_BIG_consistency
- Remove commented main from oct.c. What was in this main is now covered by the test