### PR TITLE
Fixed bug in BIG_fromBytesLen

### DIFF
--- a/src/big.c
+++ b/src/big.c
@@ -258,7 +258,7 @@ void BIG_fromBytesLen(BIG a,char *b,int s)
     int i,len=s;
     BIG_zero(a);
 
-    if (s>MODBYTES) s=MODBYTES;
+    if (len>MODBYTES) len=MODBYTES;
     for (i=0; i<len; i++)
     {
         BIG_fshl(a,8);


### PR DESCRIPTION
I think it was meant to update "len", as "s" no longer used after it has been assigned.

(If I misunderstood the code, then the line 261 can be at least removed as it is currently a dead assignment.)