### PR TITLE
Emscripten: gcc/clang compilers should only use __int128 if available

### DIFF
--- a/include/arch.h
+++ b/include/arch.h
@@ -106,8 +106,8 @@
 /**< Note - no 128-bit type available    */
 #else
 #define chunk int64_t		/**< C type corresponding to word length */
-#ifdef __GNUC__
-#define dchunk __int128		/**< Always define double length chunk type if available - GCC supports 128 bit type  ??? */
+#if defined(__SIZEOF_INT128__) && __SIZEOF_INT128__ == 16
+#define dchunk __int128                /**< Always define double length chunk type if available (supported by GCC & Clang on 64-bit architectures) */
 #endif
 #endif
 #endif


### PR DESCRIPTION
This is a patch for Emscripten (clang based but does not have a 128 bit integer, as it is currently too inefficient to implement it in Javascript).

Please have a look. Testing for __SIZEOF_INT128__ seems to be official way to make sure that __int128 is available. I think the "__SIZEOF_INT128__ == 16" check is redundant, but should not create problem, so I left it in.

The patch should work with gcc and clang.

